### PR TITLE
fix: resolve all clippy pedantic warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camino"
@@ -451,9 +451,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1352,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1364,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1375,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -2613,18 +2613,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ strsim = "0.11.1"
 strum = { version = "0.27.2", features = ["derive"] }
 thiserror = "2.0.18"
 tokio = { version = "1.49.0", features = ["full"] }
+
+[lints.clippy]
+pedantic = "warn"

--- a/src/auto_response.rs
+++ b/src/auto_response.rs
@@ -63,7 +63,7 @@ pub fn hardcoded_auto_responses() -> Vec<AutoResponseRule> {
     let rules = vec![
         AutoResponseRuleConfig {
             name: Some("jai-vu-image".to_string()),
-            user_ids: vec![398543560330444813],
+            user_ids: vec![398_543_560_330_444_813],
             content: ContentMatchConfig {
                 patterns: vec![
                     "j ai vu".to_string(),
@@ -82,7 +82,7 @@ pub fn hardcoded_auto_responses() -> Vec<AutoResponseRule> {
         },
         AutoResponseRuleConfig {
             name: Some("laugh-emoji-image".to_string()),
-            user_ids: vec![398620783498493964],
+            user_ids: vec![398_620_783_498_493_964],
             content: ContentMatchConfig {
                 patterns: vec!["😂".to_string()],
                 mode: MatchMode::Fuzzy,
@@ -245,8 +245,7 @@ fn fuzzy_match(tokens: &[&str], pattern: &str, threshold: f64, max_window: usize
             let sim = normalized_levenshtein(&candidate, pattern);
             if sim >= threshold {
                 debug!(
-                    "Auto response match: fuzzy hit (candidate='{}', pattern='{}', sim={:.3})",
-                    candidate, pattern, sim
+                    "Auto response match: fuzzy hit (candidate='{candidate}', pattern='{pattern}', sim={sim:.3})"
                 );
                 return true;
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,10 @@ pub struct Config {
 
 impl Config {
     /// Load configuration from environment variables.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if required environment variables are missing.
     pub fn from_env() -> Result<Self> {
         debug!("Loading configuration from environment");
         dotenvy::dotenv().ok();

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,15 +65,13 @@ impl From<poise::serenity_prelude::Error> for BotError {
 
 impl BotError {
     /// Returns a user-friendly error message suitable for displaying in Discord
+    #[must_use]
     pub fn user_message(&self) -> String {
         match self {
             BotError::Serenity(_) => {
                 "Sorry, I'm having trouble communicating with Discord right now. Please try again later.".to_string()
             }
-            BotError::Config(_) => {
-                "Sorry, there's a configuration issue on my end. Please contact the bot administrator.".to_string()
-            }
-            BotError::EnvVar(_) => {
+            BotError::Config(_) | BotError::EnvVar(_) => {
                 "Sorry, there's a configuration issue on my end. Please contact the bot administrator.".to_string()
             }
             BotError::OpenRouterApi { status, .. } => {
@@ -110,14 +108,11 @@ impl BotError {
             BotError::ToolLoopLimit => {
                 "Sorry, I got stuck in a loop. Please try rephrasing your request.".to_string()
             }
-            BotError::Base64Decode(_) => {
+            BotError::Base64Decode(_) | BotError::DataUrl(_) | BotError::DataUrlBase64(_) => {
                 "Sorry, I encountered an error processing image data. Please try again.".to_string()
             }
             BotError::Wav(_) => {
                 "Sorry, I encountered an error creating audio data. Please try again.".to_string()
-            }
-            BotError::DataUrl(_) | BotError::DataUrlBase64(_) => {
-                "Sorry, I encountered an error processing image data. Please try again.".to_string()
             }
             BotError::EventSource(_) => {
                 "Sorry, I encountered an error streaming audio data. Please try again.".to_string()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! LeoGPT - A Discord bot powered by OpenRouter AI.
+//! `LeoGPT` - A Discord bot powered by `OpenRouter` AI.
 
 mod auto_response;
 mod bot;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,12 @@ async fn main() -> leogpt::error::Result<()> {
     info!("Starting leogpt Discord bot");
 
     match leogpt::run().await {
-        Ok(_) => {
+        Ok(()) => {
             info!("Bot shut down successfully");
             Ok(())
         }
         Err(e) => {
-            error!("Bot encountered an error: {}", e);
+            error!("Bot encountered an error: {e}");
             Err(e)
         }
     }

--- a/src/openrouter.rs
+++ b/src/openrouter.rs
@@ -1,4 +1,4 @@
-//! OpenRouter API client for AI chat completions.
+//! `OpenRouter` API client for AI chat completions.
 
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -19,7 +19,7 @@ const COMPLETION_MODEL: &str = "google/gemini-3-flash-preview";
 /// The system prompt for the assistant.
 const SYSTEM_PROMPT: &str = "You are a helpful assistant.";
 
-/// Request payload for the OpenRouter API.
+/// Request payload for the `OpenRouter` API.
 #[derive(Debug, Serialize)]
 struct OpenRouterRequest {
     model: String,
@@ -29,7 +29,7 @@ struct OpenRouterRequest {
     tools: Option<Vec<Tool>>,
 }
 
-/// A tool definition for the OpenRouter API.
+/// A tool definition for the `OpenRouter` API.
 #[derive(Debug, Clone, Serialize)]
 pub struct Tool {
     #[serde(rename = "type")]
@@ -139,14 +139,15 @@ struct Choice {
     message: Message,
 }
 
-/// Client for interacting with the OpenRouter API.
+/// Client for interacting with the `OpenRouter` API.
 pub struct OpenRouterClient {
     api_key: String,
     client: reqwest::Client,
 }
 
 impl OpenRouterClient {
-    /// Create a new OpenRouter client.
+    /// Create a new `OpenRouter` client.
+    #[must_use]
     pub fn new(api_key: String) -> Self {
         Self {
             api_key,
@@ -155,6 +156,10 @@ impl OpenRouterClient {
     }
 
     /// Send a chat request with conversation history.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API request fails or returns an invalid response.
     pub async fn chat_with_history(
         &self,
         mut messages: Vec<Message>,
@@ -168,7 +173,7 @@ impl OpenRouterClient {
 
         // Build the full system prompt with dynamic context
         let full_system_prompt = if let Some(context) = dynamic_context {
-            format!("{}\n\n{}", context, SYSTEM_PROMPT)
+            format!("{context}\n\n{SYSTEM_PROMPT}")
         } else {
             SYSTEM_PROMPT.to_string()
         };

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,4 +1,4 @@
-//! Discord-native tools for the OpenRouter tool calling API
+//! Discord-native tools for the `OpenRouter` tool calling API
 
 mod audio_gen;
 mod definitions;

--- a/src/tools/audio_gen.rs
+++ b/src/tools/audio_gen.rs
@@ -1,4 +1,4 @@
-//! Audio generation (text-to-speech) tool implementation using OpenRouter API.
+//! Audio generation (text-to-speech) tool implementation using `OpenRouter` API.
 
 use std::io::Cursor;
 
@@ -15,7 +15,7 @@ use crate::error::{BotError, Result};
 
 use super::executor::{ToolContext, ToolOutput};
 
-/// OpenRouter chat completions API URL
+/// `OpenRouter` chat completions API URL
 const OPENROUTER_API_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
 
 /// Model for audio generation
@@ -32,7 +32,7 @@ enum AudioVoice {
     Shimmer,
 }
 
-/// Arguments for the generate_audio tool
+/// Arguments for the `generate_audio` tool
 #[derive(Debug, Deserialize)]
 struct AudioGenArgs {
     text: String,
@@ -64,7 +64,7 @@ struct AudioConfig {
     format: String,
 }
 
-/// Streaming chunk from OpenRouter
+/// Streaming chunk from `OpenRouter`
 #[derive(Debug, Deserialize)]
 struct StreamChunk {
     choices: Vec<StreamChoice>,
@@ -91,7 +91,7 @@ struct AudioDelta {
 }
 
 /// Create a WAV file from raw PCM16 audio data using the hound crate.
-/// OpenAI TTS outputs 24kHz mono 16-bit PCM.
+/// `OpenAI` TTS outputs 24kHz mono 16-bit PCM.
 fn create_wav_from_pcm16(pcm_data: &[u8]) -> Result<Vec<u8>> {
     let spec = WavSpec {
         channels: 1,
@@ -114,9 +114,9 @@ fn create_wav_from_pcm16(pcm_data: &[u8]) -> Result<Vec<u8>> {
     Ok(cursor.into_inner())
 }
 
-/// Generate audio from text using OpenRouter's multimodal API
+/// Generate audio from text using `OpenRouter`'s multimodal API
 ///
-/// Makes a request to OpenRouter with the `modalities: ["text", "audio"]` parameter
+/// Makes a request to `OpenRouter` with the `modalities: ["text", "audio"]` parameter
 /// to enable audio generation from the model.
 pub async fn generate_audio(arguments: &str, tool_ctx: &ToolContext<'_>) -> Result<ToolOutput> {
     let args: AudioGenArgs = serde_json::from_str(arguments)?;

--- a/src/tools/definitions.rs
+++ b/src/tools/definitions.rs
@@ -1,154 +1,122 @@
-//! Tool definitions for the OpenRouter tool calling API.
+//! Tool definitions for the `OpenRouter` tool calling API.
 
 use serde_json::json;
 
 use crate::openrouter::{FunctionDefinition, Tool};
 
-/// Returns the tool definitions for the OpenRouter API
-///
-/// These definitions describe the available Discord-native tools
-/// that the LLM can invoke during a conversation.
+fn tool(name: &str, description: &str, parameters: serde_json::Value) -> Tool {
+    Tool {
+        tool_type: "function".to_string(),
+        function: FunctionDefinition {
+            name: name.to_string(),
+            description: description.to_string(),
+            parameters,
+        },
+    }
+}
+
+fn search_channel_history_tool() -> Tool {
+    tool(
+        "search_channel_history",
+        "Search recent messages in the current Discord channel using semantic search. \
+         Understands meaning, not just keywords - 'food discussion' finds messages about pizza, dinner, etc. \
+         Searches up to 100 recent messages.",
+        json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "What to search for (semantic search - understands meaning)" },
+                "username": { "type": "string", "description": "Filter messages by author name (fuzzy match)" },
+                "limit": { "type": "integer", "description": "Maximum number of results to return (default: 20, max: 100)" }
+            },
+            "required": []
+        }),
+    )
+}
+
+fn get_user_info_tool() -> Tool {
+    tool(
+        "get_user_info",
+        "Get detailed information about a Discord user in the current server. \
+         Returns user ID, mention string (use this directly in your response to tag/ping the user), \
+         roles, join date, and avatar. To mention the user, include the 'mention' field value \
+         exactly as returned (e.g., <@123456789>) in your response text.",
+        json!({
+            "type": "object",
+            "properties": {
+                "username": { "type": "string", "description": "Username or display name to search for (fuzzy match)" },
+                "user_id": { "type": "string", "description": "Discord user ID (exact match)" }
+            },
+            "required": []
+        }),
+    )
+}
+
+fn get_server_info_tool() -> Tool {
+    tool(
+        "get_server_info",
+        "Get detailed information about the current Discord server, including member count, boost level, channels, and roles.",
+        json!({ "type": "object", "properties": {}, "required": [] }),
+    )
+}
+
+fn web_search_tool() -> Tool {
+    tool(
+        "web_search",
+        "Search the web for current information, news, or facts. \
+         Use when the user asks about recent events or topics that may have changed since your knowledge cutoff.",
+        json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "The search query" }
+            },
+            "required": ["query"]
+        }),
+    )
+}
+
+fn generate_image_tool() -> Tool {
+    tool(
+        "generate_image",
+        "Generate or edit images using AI. Creates new images from text descriptions, \
+         or edits images from the conversation if the prompt requests modifications. \
+         The model automatically sees recent images from the conversation.",
+        json!({
+            "type": "object",
+            "properties": {
+                "prompt": { "type": "string", "description": "Description of image to generate, or editing instructions (e.g., 'make it purple', 'add a hat')" },
+                "aspect_ratio": { "type": "string", "description": "Aspect ratio (1:1, 16:9, 9:16, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 21:9). Default: 1:1" },
+                "size": { "type": "string", "description": "Image resolution (1K, 2K, 4K). Default: 1K" }
+            },
+            "required": ["prompt"]
+        }),
+    )
+}
+
+fn generate_audio_tool() -> Tool {
+    tool(
+        "generate_audio",
+        "Generate spoken audio from text using text-to-speech. Converts written text into natural-sounding speech. \
+         Useful for voice responses, narration, or reading text aloud.",
+        json!({
+            "type": "object",
+            "properties": {
+                "text": { "type": "string", "description": "The text to convert to speech (max 4096 characters)" },
+                "voice": { "type": "string", "description": "Voice to use: alloy (neutral), echo (male), fable (British), onyx (deep male), nova (female), shimmer (soft female). Default: alloy" }
+            },
+            "required": ["text"]
+        }),
+    )
+}
+
+/// Returns the tool definitions for the `OpenRouter` API.
+#[must_use]
 pub fn get_tool_definitions() -> Vec<Tool> {
     vec![
-        Tool {
-            tool_type: "function".to_string(),
-            function: FunctionDefinition {
-                name: "search_channel_history".to_string(),
-                description: "Search recent messages in the current Discord channel using \
-                    semantic search. Understands meaning, not just keywords - 'food discussion' \
-                    finds messages about pizza, dinner, etc. Searches up to 100 recent messages."
-                    .to_string(),
-                parameters: json!({
-                    "type": "object",
-                    "properties": {
-                        "query": {
-                            "type": "string",
-                            "description": "What to search for (semantic search - understands meaning)"
-                        },
-                        "username": {
-                            "type": "string",
-                            "description": "Filter messages by author name (fuzzy match)"
-                        },
-                        "limit": {
-                            "type": "integer",
-                            "description": "Maximum number of results to return (default: 20, max: 100)"
-                        }
-                    },
-                    "required": []
-                }),
-            },
-        },
-        Tool {
-            tool_type: "function".to_string(),
-            function: FunctionDefinition {
-                name: "get_user_info".to_string(),
-                description:
-                    "Get detailed information about a Discord user in the current server. \
-                    Returns user ID, mention string (use this directly in your response to tag/ping the user), \
-                    roles, join date, and avatar. To mention the user, include the 'mention' field value \
-                    exactly as returned (e.g., <@123456789>) in your response text."
-                        .to_string(),
-                parameters: json!({
-                    "type": "object",
-                    "properties": {
-                        "username": {
-                            "type": "string",
-                            "description": "Username or display name to search for (fuzzy match)"
-                        },
-                        "user_id": {
-                            "type": "string",
-                            "description": "Discord user ID (exact match)"
-                        }
-                    },
-                    "required": []
-                }),
-            },
-        },
-        Tool {
-            tool_type: "function".to_string(),
-            function: FunctionDefinition {
-                name: "get_server_info".to_string(),
-                description: "Get detailed information about the current Discord server, \
-                    including member count, boost level, channels, and roles."
-                    .to_string(),
-                parameters: json!({
-                    "type": "object",
-                    "properties": {},
-                    "required": []
-                }),
-            },
-        },
-        Tool {
-            tool_type: "function".to_string(),
-            function: FunctionDefinition {
-                name: "web_search".to_string(),
-                description: "Search the web for current information, news, or facts. \
-                    Use when the user asks about recent events or topics that may have \
-                    changed since your knowledge cutoff."
-                    .to_string(),
-                parameters: json!({
-                    "type": "object",
-                    "properties": {
-                        "query": {
-                            "type": "string",
-                            "description": "The search query"
-                        }
-                    },
-                    "required": ["query"]
-                }),
-            },
-        },
-        Tool {
-            tool_type: "function".to_string(),
-            function: FunctionDefinition {
-                name: "generate_image".to_string(),
-                description: "Generate or edit images using AI. Creates new images from text \
-                    descriptions, or edits images from the conversation if the prompt requests \
-                    modifications. The model automatically sees recent images from the conversation."
-                    .to_string(),
-                parameters: json!({
-                    "type": "object",
-                    "properties": {
-                        "prompt": {
-                            "type": "string",
-                            "description": "Description of image to generate, or editing instructions (e.g., 'make it purple', 'add a hat')"
-                        },
-                        "aspect_ratio": {
-                            "type": "string",
-                            "description": "Aspect ratio (1:1, 16:9, 9:16, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 21:9). Default: 1:1"
-                        },
-                        "size": {
-                            "type": "string",
-                            "description": "Image resolution (1K, 2K, 4K). Default: 1K"
-                        }
-                    },
-                    "required": ["prompt"]
-                }),
-            },
-        },
-        Tool {
-            tool_type: "function".to_string(),
-            function: FunctionDefinition {
-                name: "generate_audio".to_string(),
-                description: "Generate spoken audio from text using text-to-speech. Converts \
-                    written text into natural-sounding speech that can be played back. Useful \
-                    for voice responses, narration, or reading text aloud."
-                    .to_string(),
-                parameters: json!({
-                    "type": "object",
-                    "properties": {
-                        "text": {
-                            "type": "string",
-                            "description": "The text to convert to speech (max 4096 characters)"
-                        },
-                        "voice": {
-                            "type": "string",
-                            "description": "Voice to use: alloy (neutral), echo (male), fable (British), onyx (deep male), nova (female), shimmer (soft female). Default: alloy"
-                        }
-                    },
-                    "required": ["text"]
-                }),
-            },
-        },
+        search_channel_history_tool(),
+        get_user_info_tool(),
+        get_server_info_tool(),
+        web_search_tool(),
+        generate_image_tool(),
+        generate_audio_tool(),
     ]
 }

--- a/src/tools/executor.rs
+++ b/src/tools/executor.rs
@@ -50,6 +50,7 @@ pub struct ToolOutput {
 
 impl ToolOutput {
     /// Create a text-only output
+    #[must_use]
     pub fn text(text: String) -> Self {
         Self {
             text,
@@ -59,6 +60,7 @@ impl ToolOutput {
     }
 
     /// Create an output with both text and an image
+    #[must_use]
     pub fn with_image(text: String, data: Vec<u8>, filename: String) -> Self {
         Self {
             text,
@@ -68,6 +70,7 @@ impl ToolOutput {
     }
 
     /// Create an output with both text and audio
+    #[must_use]
     pub fn with_audio(text: String, data: Vec<u8>, filename: String) -> Self {
         Self {
             text,
@@ -81,13 +84,17 @@ impl ToolOutput {
 pub struct ToolExecutor;
 
 impl ToolExecutor {
-    /// Execute a tool by name with the given JSON arguments
+    /// Execute a tool by name with the given JSON arguments.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the tool execution fails or the tool is unknown.
     pub async fn execute(
         name: &str,
         arguments: &str,
         tool_ctx: &ToolContext<'_>,
     ) -> Result<ToolOutput> {
-        debug!("Executing tool '{}' with args: {}", name, arguments);
+        debug!("Executing tool '{name}' with args: {arguments}");
 
         match name {
             "search_channel_history" => search_channel_history(arguments, tool_ctx)
@@ -105,8 +112,8 @@ impl ToolExecutor {
             "generate_image" => generate_image(arguments, tool_ctx).await,
             "generate_audio" => generate_audio(arguments, tool_ctx).await,
             _ => {
-                warn!("Unknown tool requested: {}", name);
-                Err(BotError::ToolExecution(format!("Unknown tool: {}", name)))
+                warn!("Unknown tool requested: {name}");
+                Err(BotError::ToolExecution(format!("Unknown tool: {name}")))
             }
         }
     }

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -14,13 +14,13 @@ use super::utils::matches_username;
 /// Maximum messages Discord API returns per request
 const MAX_MESSAGES: u8 = 100;
 
-/// OpenRouter embeddings API URL
+/// `OpenRouter` embeddings API URL
 const EMBEDDINGS_URL: &str = "https://openrouter.ai/api/v1/embeddings";
 
 /// Embedding model to use for semantic search
 const EMBEDDING_MODEL: &str = "google/gemini-embedding-001";
 
-/// Arguments for the search_channel_history tool
+/// Arguments for the `search_channel_history` tool
 #[derive(Debug, Deserialize)]
 struct SearchArgs {
     query: Option<String>,
@@ -38,14 +38,14 @@ struct MessageResult {
     similarity: Option<f32>,
 }
 
-/// Request payload for the OpenRouter embeddings API
+/// Request payload for the `OpenRouter` embeddings API
 #[derive(Debug, Serialize)]
 struct EmbeddingRequest {
     model: String,
     input: Vec<String>,
 }
 
-/// Response from the OpenRouter embeddings API
+/// Response from the `OpenRouter` embeddings API
 #[derive(Debug, Deserialize)]
 struct EmbeddingResponse {
     data: Vec<EmbeddingData>,
@@ -71,7 +71,7 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     dot / (norm_a * norm_b)
 }
 
-/// Get embeddings from OpenRouter API
+/// Get embeddings from `OpenRouter` API
 async fn get_embeddings(texts: &[String], api_key: &str) -> Result<Vec<Vec<f32>>> {
     if texts.is_empty() {
         return Ok(vec![]);

--- a/src/tools/server_info.rs
+++ b/src/tools/server_info.rs
@@ -7,7 +7,7 @@ use crate::error::{BotError, Result};
 
 use super::executor::ToolContext;
 
-/// Arguments for the get_server_info tool
+/// Arguments for the `get_server_info` tool
 #[derive(Debug, Deserialize)]
 struct ServerInfoArgs {
     // No arguments needed - uses current server context

--- a/src/tools/user_info.rs
+++ b/src/tools/user_info.rs
@@ -9,7 +9,7 @@ use crate::error::{BotError, Result};
 use super::executor::ToolContext;
 use super::utils::matches_username;
 
-/// Arguments for the get_user_info tool
+/// Arguments for the `get_user_info` tool
 #[derive(Debug, Deserialize)]
 struct UserInfoArgs {
     username: Option<String>,
@@ -64,7 +64,7 @@ pub async fn get_user_info(arguments: &str, tool_ctx: &ToolContext<'_>) -> Resul
                             .as_ref()
                             .is_some_and(|n| matches_username(n, username))
                 })
-                .ok_or_else(|| BotError::ToolExecution(format!("User '{}' not found", username)))?
+                .ok_or_else(|| BotError::ToolExecution(format!("User '{username}' not found")))?
         }
         (None, None) => {
             return Err(BotError::ToolExecution(
@@ -86,7 +86,7 @@ pub async fn get_user_info(arguments: &str, tool_ctx: &ToolContext<'_>) -> Resul
     let user_id = member.user.id.to_string();
     let result = UserInfoResult {
         user_id: user_id.clone(),
-        mention: format!("<@{}>", user_id),
+        mention: format!("<@{user_id}>"),
         username: member.user.name.clone(),
         display_name: member.user.global_name.clone(),
         avatar_url: member.user.avatar_url(),

--- a/src/tools/web_search.rs
+++ b/src/tools/web_search.rs
@@ -1,4 +1,4 @@
-//! Web search tool implementation using OpenRouter's online search.
+//! Web search tool implementation using `OpenRouter`'s online search.
 
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,7 @@ const OPENROUTER_API_URL: &str = "https://openrouter.ai/api/v1/chat/completions"
 /// Model for web search requests.
 const WEB_SEARCH_MODEL: &str = "google/gemini-2.5-flash-lite";
 
-/// Arguments for the web_search tool
+/// Arguments for the `web_search` tool
 #[derive(Debug, Deserialize)]
 struct WebSearchArgs {
     query: String,
@@ -31,7 +31,7 @@ struct RequestMessage {
     content: String,
 }
 
-/// Response from OpenRouter
+/// Response from `OpenRouter`
 #[derive(Debug, Deserialize)]
 struct OpenRouterResponse {
     choices: Vec<Choice>,
@@ -49,16 +49,16 @@ struct ResponseMessage {
     content: Option<String>,
 }
 
-/// Perform a web search using OpenRouter's online search capability
+/// Perform a web search using `OpenRouter`'s online search capability
 ///
-/// Makes a request to OpenRouter with the `:online` suffix appended to the model,
+/// Makes a request to `OpenRouter` with the `:online` suffix appended to the model,
 /// which enables web search for that request.
 pub async fn web_search(arguments: &str, api_key: &str) -> Result<String> {
     let args: WebSearchArgs = serde_json::from_str(arguments)?;
 
     debug!("Performing web search for: {}", args.query);
 
-    let online_model = format!("{}:online", WEB_SEARCH_MODEL);
+    let online_model = format!("{WEB_SEARCH_MODEL}:online");
 
     let request = WebSearchRequest {
         model: online_model,

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// Role of a message in the conversation.
 ///
-/// Maps to OpenRouter API message roles.
+/// Maps to `OpenRouter` API message roles.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MessageRole {
@@ -21,12 +21,12 @@ pub enum MessageRole {
 
 /// Supported media types for attachments.
 ///
-/// Determines how Discord attachments are processed for the OpenRouter API.
+/// Determines how Discord attachments are processed for the `OpenRouter` API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MediaType {
     /// Image files (PNG, JPEG, GIF, WebP)
     Image,
-    /// Video files (MP4, WebM)
+    /// Video files (MP4, `WebM`)
     Video,
     /// Audio files (MP3, WAV, OGG, FLAC)
     Audio,
@@ -36,6 +36,7 @@ pub enum MediaType {
 
 impl MediaType {
     /// Determine media type from a MIME content type string
+    #[must_use]
     pub fn from_content_type(content_type: &str) -> Option<MediaType> {
         let mime: Mime = content_type.parse().ok()?;
         match (mime.type_(), mime.subtype()) {
@@ -48,13 +49,14 @@ impl MediaType {
     }
 }
 
-/// Audio format for OpenRouter API
+/// Audio format for `OpenRouter` API
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AudioFormat(String);
 
 impl AudioFormat {
     /// Convert a MIME type to an audio format string
     /// e.g., "audio/mpeg" -> "mp3", "audio/wav" -> "wav"
+    #[must_use]
     pub fn from_mime_type(mime_type: &str) -> Self {
         let format = mime_type
             .parse::<Mime>()
@@ -67,7 +69,8 @@ impl AudioFormat {
         AudioFormat(format.to_string())
     }
 
-    /// Returns the format string for the OpenRouter API
+    /// Returns the format string for the `OpenRouter` API
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }


### PR DESCRIPTION
  - Add underscores to large numeric literals for readability
  - Replace format_push_string with write! to avoid extra allocations
  - Add # Errors doc sections to public Result-returning functions
  - Refactor long functions into smaller helpers:
    - Extract run_tool_loop and send_response from handle_bot_mention
    - Extract individual tool definition functions
    - Extract build_image_config, build_message_content, extract_image_from_response
  - Use let...else syntax instead of match for early returns
  - Merge identical match arms in BotError::user_message
